### PR TITLE
allow users of lib to omit 'path' tag

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -2,6 +2,7 @@ package httpstats
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -11,6 +12,10 @@ import (
 	"github.com/asecurityteam/settings"
 	"github.com/rs/xstats"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testdependency = "testdependency"
 )
 
 func TestMetricsConfigName(t *testing.T) {
@@ -31,7 +36,7 @@ func TestMetricsComponentNew(t *testing.T) {
 func TestNew(t *testing.T) {
 	src := settings.NewMapSource(map[string]interface{}{
 		"metrics": map[string]interface{}{
-			"backend": "testdependency",
+			"backend": testdependency,
 		},
 	})
 	wrapper, err := New(context.Background(), src)
@@ -40,7 +45,7 @@ func TestNew(t *testing.T) {
 
 	tr := wrapper(http.DefaultTransport)
 	assert.Equal(
-		t, "client_dependency:testdependency",
+		t, fmt.Sprintf("client_dependency:%s", testdependency),
 		reflect.Indirect(reflect.ValueOf(tr)).FieldByName("tags").Index(0).String(),
 	)
 }
@@ -57,7 +62,7 @@ func TestMetricsComponentNewNoDependencyError(t *testing.T) {
 func TestMetricsComponentNewStaticPath(t *testing.T) {
 	cmp := NewComponent()
 	conf := cmp.Settings()
-	conf.Backend = "testdependency"
+	conf.Backend = testdependency
 	conf.Path = "/foo"
 	wrapper, err := cmp.New(context.Background(), conf)
 	assert.Nil(t, err)
@@ -66,14 +71,14 @@ func TestMetricsComponentNewStaticPath(t *testing.T) {
 	tr := wrapper(http.DefaultTransport)
 	tags := reflect.Indirect(reflect.ValueOf(tr)).FieldByName("tags")
 	for i := 0; i < tags.Len(); i++ {
-		assert.Contains(t, []string{"client_dependency:testdependency", "client_path:/foo"}, tags.Index(i).String())
+		assert.Contains(t, []string{fmt.Sprintf("client_dependency:%s", testdependency), "client_path:/foo"}, tags.Index(i).String())
 	}
 }
 
 func TestMetricsComponentNonStaticPath(t *testing.T) {
 	cmp := NewComponent()
 	conf := cmp.Settings()
-	conf.Backend = "testdependency"
+	conf.Backend = testdependency
 	wrapper, err := cmp.New(context.Background(), conf)
 	assert.Nil(t, err)
 	assert.IsType(t, wrapper, func(next http.RoundTripper) http.RoundTripper { return nil }, wrapper)
@@ -91,7 +96,7 @@ func TestMetricsComponentNonStaticPath(t *testing.T) {
 
 	expectedTags := []string{
 		"client_path:/some/random/path",
-		"client_dependency:testdependency",
+		fmt.Sprintf("client_dependency:%s", testdependency),
 		"method:",
 		"status_code:502",
 		"status:error",
@@ -107,7 +112,7 @@ func TestMetricsComponentNonStaticPath(t *testing.T) {
 func TestMetricsComponentNewStaticPathOmitPath(t *testing.T) {
 	cmp := NewComponent()
 	conf := cmp.Settings()
-	conf.Backend = "testdependency"
+	conf.Backend = testdependency
 	conf.Path = "/foo"
 	conf.OmitPathTag = true
 	wrapper, err := cmp.New(context.Background(), conf)
@@ -117,14 +122,14 @@ func TestMetricsComponentNewStaticPathOmitPath(t *testing.T) {
 	tr := wrapper(http.DefaultTransport)
 	tags := reflect.Indirect(reflect.ValueOf(tr)).FieldByName("tags")
 	for i := 0; i < tags.Len(); i++ {
-		assert.Contains(t, []string{"client_dependency:testdependency"}, tags.Index(i).String())
+		assert.Contains(t, []string{fmt.Sprintf("client_dependency:%s", testdependency)}, tags.Index(i).String())
 	}
 }
 
 func TestMetricsComponentNewNoPathGiven(t *testing.T) {
 	cmp := NewComponent()
 	conf := cmp.Settings()
-	conf.Backend = "testdependency"
+	conf.Backend = testdependency
 	wrapper, err := cmp.New(context.Background(), conf)
 	assert.Nil(t, err)
 	assert.IsType(t, wrapper, func(next http.RoundTripper) http.RoundTripper { return nil }, wrapper)


### PR DESCRIPTION
In order to support usage of this stats lib as a transport chain middleware ("tripperware", because it's a roundtripper thing), but with an http client having APIs like `/api/v1/getthingbyid/{id}` where the {id} can vary by hundreds of thousands, or millions, we need a way to mitigate the risk of a "cardinality explosion" in the target stats host.

I can think of more robust, configurable solutions, like allowing users of the lib to set a "regex replace" pattern for paths, but the cognitive burden on the engineer to 1) know all the possible paths of the API they'll call, and 2) properly make regexes to perform the replacement, and 3) perform unit/integration tests to prove it out, is fairly high burden.

Anyway, this PR is simple enough, is backwards compatible (so I'll do a minor version update), and easy to understand.